### PR TITLE
Unvendor leatherman

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/leatherman"]
-	path = vendor/leatherman
-	url = https://github.com/puppetlabs/leatherman

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ before_install:
   # grab a pre-built cmake 3.2.3
   - wget --no-check-certificate https://cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
   - tar xzvf cmake-3.2.3-Linux-x86_64.tar.gz --strip 1 -C $USERDIR
+  # grab a released leatherman tarball
+  - wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman.tar.gz
+  - tar xzvf leatherman.tar.gz -C $USERDIR
 
 script:
   - ./.travis_target.sh
@@ -35,6 +38,7 @@ env:
     - PYTHONUSERBASE=$USERDIR
     - PATH=$USERDIR/bin:$PATH
     - LD_LIBRARY_PATH=$USERDIR/lib:$LD_LIBRARY_PATH
+    - LEATHERMAN_VERSION=0.3.4
   matrix:
     - TRAVIS_TARGET=DOXYGEN
     - TRAVIS_TARGET=CPPLINT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,30 @@ endif()
 
 enable_testing()
 
-# Leatherman setup
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/vendor/leatherman/cmake")
+include(FeatureSummary)
 
-## Before we find any packages, we want to pull in the common leatherman options, as they can affect commonly-used packages.
+SET(LEATHERMAN_COMPONENTS locale catch nowide logging util file_util dynamic_library execution ruby rapidjson)
+
+# We look for curl early, because whether or not we link to the leatherman curl library
+# is dependent on whether or not we find curl on the system.
+if ((("${CMAKE_SYSTEM_NAME}" MATCHES "Linux") OR WIN32) AND NOT WITHOUT_CURL)
+    find_package(CURL)
+    if (CURL_FOUND)
+        add_definitions(-DUSE_CURL)
+        list(APPEND LEATHERMAN_COMPONENTS curl)
+    endif()
+    set_package_properties(CURL PROPERTIES DESCRIPTION "A free and easy-to-use client-side URL transfer library" URL "http://curl.haxx.se/libcurl/")
+    set_package_properties(CURL PROPERTIES TYPE OPTIONAL PURPOSE "Enables facts that require HTTP.")
+endif()
+
+if (WIN32)
+    list(APPEND LEATHERMAN_COMPONENTS windows)
+endif()
+
+find_package(Leatherman REQUIRED COMPONENTS ${LEATHERMAN_COMPONENTS})
+
+# Now that we have leatherman, we can pull in its options file, which
+# we need for finding all our other libraries.
 include(options)
 ## Pull in common cflags setting from leatherman. Don't override CMAKE_CXX_FLAGS at the project root to avoid impacting 3rd party code.
 include(cflags)
@@ -36,13 +56,6 @@ find_package(Boost 1.54 REQUIRED COMPONENTS program_options)
 # Display a summary of the features
 include(FeatureSummary)
 feature_summary(WHAT ALL)
-
-# Add build directories, both Leatherman and the project's source code
-set(LEATHERMAN_USE_LOCALE TRUE)
-set(LEATHERMAN_USE_CATCH TRUE)
-set(LEATHERMAN_USE_NOWIDE TRUE)
-set(LEATHERMAN_USE_LOGGING TRUE)
-add_subdirectory("vendor/leatherman")
 
 add_subdirectory(lib)
 add_subdirectory(exe)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+version: 0.0.1.{build}
+clone_depth: 10
+environment:
+  LEATHERMAN_VERSION: 0.3.4
 install:
   - git submodule update --init --recursive
 
@@ -13,6 +17,12 @@ install:
 build_script:
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -Wno-dev .
   - ps: mingw32-make install
+
+  - ps: wget "https://github.com/puppetlabs/leatherman/releases/download/$env:LEATHERMAN_VERSION/leatherman.7z" -OutFile "$pwd\leatherman.7z"
+  - ps: 7z.exe x leatherman.7z -oC:\tools | FIND /V "ing "
+
+  - gem install bundler --quiet --no-ri --no-rdoc
+  - bundle install --jobs 4 --retry 2 --gemfile=lib/Gemfile --quiet
 
 test_script:
   - ps: ctest -V 2>&1 | %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_ | c++filt } else { $_ } }


### PR DESCRIPTION
This updates the CMake to assume leatherman needs to be found on the
system, and updates the travis and appveyorbuild scripts to use an
artifact provided from a github release.
